### PR TITLE
chore: backport transfer-hook extra-account resolution onto v0.9.0

### DIFF
--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -12,7 +12,7 @@ jobs:
         fuzz_target: [token-swap-instructions]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set env vars
         run: |
@@ -27,7 +27,7 @@ jobs:
           override: true
           profile: minimal
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -35,14 +35,14 @@ jobs:
             target
           key: cargo-fuzz-${{ hashFiles('**/Cargo.lock') }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/cargo-hfuzz
             ~/.cargo/bin/cargo-honggfuzz
           key: cargo-fuzz-bins-${{ runner.os }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/solana
           key: solana-${{ env.SOLANA_VERSION }}

--- a/.github/workflows/pull-request-account-compression.yml
+++ b/.github/workflows/pull-request-account-compression.yml
@@ -21,7 +21,7 @@ jobs:
   anchor-build-account-compression:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set env vars
         run: |
@@ -38,20 +38,20 @@ jobs:
           override: true
           profile: minimal
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
           key: cargo-build-${{ hashFiles('**/Cargo.lock') }}-${{ env.RUST_STABLE }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/rustfilt
           key: cargo-sbf-bins-${{ runner.os }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/solana
           key: solana-${{ env.SOLANA_VERSION }}
@@ -66,7 +66,7 @@ jobs:
           ./ci/anchor-build.sh account-compression
 
       - name: Upload programs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: account-compression-programs
           path: "account-compression/target/deploy/*.so"
@@ -78,19 +78,19 @@ jobs:
       NODE_VERSION: 16.x
     needs: anchor-build-account-compression
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/yarn
           key: node-${{ hashFiles('account-compression/sdk/yarn.lock') }}
           restore-keys: |
             node-
       - name: Download programs
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: account-compression-programs
           path: account-compression/target/deploy

--- a/.github/workflows/pull-request-binary-oracle-pair.yml
+++ b/.github/workflows/pull-request-binary-oracle-pair.yml
@@ -17,7 +17,7 @@ jobs:
   cargo-test-sbf:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set env vars
         run: |
@@ -32,20 +32,20 @@ jobs:
           override: true
           profile: minimal
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
           key: cargo-build-${{ hashFiles('**/Cargo.lock') }}-${{ env.RUST_STABLE}}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/rustfilt
           key: cargo-sbf-bins-${{ runner.os }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/solana
           key: solana-${{ env.SOLANA_VERSION }}

--- a/.github/workflows/pull-request-docs.yml
+++ b/.github/workflows/pull-request-docs.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
 
@@ -49,8 +49,8 @@ jobs:
   build_docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '18'
       - name: "Build Docs"

--- a/.github/workflows/pull-request-examples.yml
+++ b/.github/workflows/pull-request-examples.yml
@@ -15,7 +15,7 @@ jobs:
   cargo-test-sbf:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set env vars
         run: |
@@ -30,20 +30,20 @@ jobs:
           override: true
           profile: minimal
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
           key: cargo-build-${{ hashFiles('**/Cargo.lock') }}-${{ env.RUST_STABLE}}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/rustfilt
           key: cargo-sbf-bins-${{ runner.os }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/solana
           key: solana-${{ env.SOLANA_VERSION }}

--- a/.github/workflows/pull-request-feature-proposal.yml
+++ b/.github/workflows/pull-request-feature-proposal.yml
@@ -17,7 +17,7 @@ jobs:
   cargo-test-sbf:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set env vars
         run: |
@@ -32,20 +32,20 @@ jobs:
           override: true
           profile: minimal
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
           key: cargo-build-${{ hashFiles('**/Cargo.lock') }}-${{ env.RUST_STABLE}}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/rustfilt
           key: cargo-sbf-bins-${{ runner.os }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/solana
           key: solana-${{ env.SOLANA_VERSION }}

--- a/.github/workflows/pull-request-governance.yml
+++ b/.github/workflows/pull-request-governance.yml
@@ -27,7 +27,7 @@ jobs:
           sudo rm -rf "/usr/local/share/boost"
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set env vars
         run: |
@@ -42,20 +42,20 @@ jobs:
           override: true
           profile: minimal
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
           key: cargo-build-${{ hashFiles('**/Cargo.lock') }}-${{ env.RUST_STABLE}}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/rustfilt
           key: cargo-sbf-bins-${{ runner.os }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/solana
           key: solana-${{ env.SOLANA_VERSION }}

--- a/.github/workflows/pull-request-instruction-padding.yml
+++ b/.github/workflows/pull-request-instruction-padding.yml
@@ -17,7 +17,7 @@ jobs:
   cargo-test-sbf:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set env vars
         run: |
@@ -32,20 +32,20 @@ jobs:
           override: true
           profile: minimal
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
           key: cargo-build-${{ hashFiles('**/Cargo.lock') }}-${{ env.RUST_STABLE}}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/rustfilt
           key: cargo-sbf-bins-${{ runner.os }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/solana
           key: solana-${{ env.SOLANA_VERSION }}

--- a/.github/workflows/pull-request-libraries.yml
+++ b/.github/workflows/pull-request-libraries.yml
@@ -15,7 +15,7 @@ jobs:
   cargo-test-sbf:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set env vars
         run: |
@@ -30,20 +30,20 @@ jobs:
           override: true
           profile: minimal
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
           key: cargo-build-${{ hashFiles('**/Cargo.lock') }}-${{ env.RUST_STABLE}}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/rustfilt
           key: cargo-sbf-bins-${{ runner.os }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/solana
           key: solana-${{ env.SOLANA_VERSION }}
@@ -62,12 +62,12 @@ jobs:
     env:
       NODE_VERSION: 16.x
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.npm
           key: node-${{ hashFiles('libraries/type-length-value/js/package-lock.json') }}

--- a/.github/workflows/pull-request-memo.yml
+++ b/.github/workflows/pull-request-memo.yml
@@ -15,7 +15,7 @@ jobs:
   cargo-test-sbf:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set env vars
         run: |
@@ -30,20 +30,20 @@ jobs:
           override: true
           profile: minimal
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
           key: cargo-build-${{ hashFiles('**/Cargo.lock') }}-${{ env.RUST_STABLE}}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/rustfilt
           key: cargo-sbf-bins-${{ runner.os }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/solana
           key: solana-${{ env.SOLANA_VERSION }}
@@ -62,12 +62,12 @@ jobs:
     env:
       NODE_VERSION: 16.x
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.npm
           key: node-${{ hashFiles('memo/js/package-lock.json') }}

--- a/.github/workflows/pull-request-name-service.yml
+++ b/.github/workflows/pull-request-name-service.yml
@@ -15,7 +15,7 @@ jobs:
   cargo-test-sbf:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set env vars
         run: |
@@ -30,20 +30,20 @@ jobs:
           override: true
           profile: minimal
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
           key: cargo-build-${{ hashFiles('**/Cargo.lock') }}-${{ env.RUST_STABLE}}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/rustfilt
           key: cargo-sbf-bins-${{ runner.os }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/solana
           key: solana-${{ env.SOLANA_VERSION }}
@@ -58,7 +58,7 @@ jobs:
         run: ./ci/cargo-test-sbf.sh name-service
 
       - name: Upload programs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: name-service-programs
           path: "target/deploy/*.so"
@@ -70,19 +70,19 @@ jobs:
       NODE_VERSION: 16.x
     needs: cargo-test-sbf
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/yarn
           key: node-${{ hashFiles('name-service/js/yarn.lock') }}
           restore-keys: |
             node-
       - name: Download programs
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: name-service-programs
           path: target/deploy

--- a/.github/workflows/pull-request-record.yml
+++ b/.github/workflows/pull-request-record.yml
@@ -15,7 +15,7 @@ jobs:
   cargo-test-sbf:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set env vars
         run: |
@@ -30,20 +30,20 @@ jobs:
           override: true
           profile: minimal
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
           key: cargo-build-${{ hashFiles('**/Cargo.lock') }}-${{ env.RUST_STABLE}}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/rustfilt
           key: cargo-sbf-bins-${{ runner.os }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/solana
           key: solana-${{ env.SOLANA_VERSION }}

--- a/.github/workflows/pull-request-shared-memory.yml
+++ b/.github/workflows/pull-request-shared-memory.yml
@@ -15,7 +15,7 @@ jobs:
   cargo-test-sbf:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set env vars
         run: |
@@ -30,20 +30,20 @@ jobs:
           override: true
           profile: minimal
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
           key: cargo-build-${{ hashFiles('**/Cargo.lock') }}-${{ env.RUST_STABLE}}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/rustfilt
           key: cargo-sbf-bins-${{ runner.os }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/solana
           key: solana-${{ env.SOLANA_VERSION }}

--- a/.github/workflows/pull-request-single-pool.yml
+++ b/.github/workflows/pull-request-single-pool.yml
@@ -21,7 +21,7 @@ jobs:
   cargo-test-sbf:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set env vars
         run: |
@@ -36,20 +36,20 @@ jobs:
           override: true
           profile: minimal
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
           key: cargo-build-${{ hashFiles('**/Cargo.lock') }}-${{ env.RUST_STABLE}}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/rustfilt
           key: cargo-sbf-bins-${{ runner.os }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/solana
           key: solana-${{ env.SOLANA_VERSION }}
@@ -64,7 +64,7 @@ jobs:
         run: ./ci/cargo-test-sbf.sh single-pool/program
 
       - name: Upload programs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: single-pool-programs
           path: "target/deploy/*.so"
@@ -73,7 +73,7 @@ jobs:
   cargo-build-test-cli:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set env vars
         run: |
@@ -88,14 +88,14 @@ jobs:
           override: true
           profile: minimal
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
           key: cargo-build-${{ hashFiles('**/Cargo.lock') }}-${{ env.RUST_STABLE }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/solana
           key: solana-${{ env.SOLANA_VERSION }}
@@ -121,16 +121,16 @@ jobs:
       NODE_VERSION: 18.x
     needs: cargo-test-sbf
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
       - uses: pnpm/action-setup@v2
         with:
           version: 8
       - name: Download programs
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: single-pool-programs
           path: target/deploy

--- a/.github/workflows/pull-request-stake-pool.yml
+++ b/.github/workflows/pull-request-stake-pool.yml
@@ -21,7 +21,7 @@ jobs:
   cargo-test-sbf:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Check disk space
         run: df -h
@@ -45,20 +45,20 @@ jobs:
           override: true
           profile: minimal
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
           key: cargo-build-${{ hashFiles('**/Cargo.lock') }}-${{ env.RUST_STABLE}}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/rustfilt
           key: cargo-sbf-bins-${{ runner.os }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/solana
           key: solana-${{ env.SOLANA_VERSION }}
@@ -73,7 +73,7 @@ jobs:
         run: ./ci/cargo-test-sbf.sh stake-pool
 
       - name: Upload programs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: stake-pool-programs
           path: "target/deploy/*.so"
@@ -85,19 +85,19 @@ jobs:
       NODE_VERSION: 16.x
     needs: cargo-test-sbf
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.npm
           key: node-${{ hashFiles('stake-pool/js/package-lock.json') }}
           restore-keys: |
             node-
       - name: Download programs
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: stake-pool-programs
           path: target/deploy
@@ -107,20 +107,20 @@ jobs:
     runs-on: ubuntu-latest
     needs: cargo-test-sbf
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup Python version
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: pip-stake-pool-${{ hashFiles('stake-pool/py/requirements.txt') }}
 
       - name: Download programs
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: stake-pool-programs
           path: target/deploy

--- a/.github/workflows/pull-request-token-lending.yml
+++ b/.github/workflows/pull-request-token-lending.yml
@@ -17,7 +17,7 @@ jobs:
   cargo-test-sbf:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set env vars
         run: |
@@ -32,20 +32,20 @@ jobs:
           override: true
           profile: minimal
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
           key: cargo-build-${{ hashFiles('**/Cargo.lock') }}-${{ env.RUST_STABLE}}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/rustfilt
           key: cargo-sbf-bins-${{ runner.os }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/solana
           key: solana-${{ env.SOLANA_VERSION }}
@@ -60,7 +60,7 @@ jobs:
         run: ./ci/cargo-test-sbf.sh token-lending
 
       - name: Upload programs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: token-lending-programs
           path: "target/deploy/*.so"
@@ -72,19 +72,19 @@ jobs:
       NODE_VERSION: 16.x
     needs: cargo-test-sbf
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.npm
           key: node-${{ hashFiles('token-lending/js/package-lock.json') }}
           restore-keys: |
             node-
       - name: Download programs
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: token-lending-programs
           path: target/deploy

--- a/.github/workflows/pull-request-token-metadata.yml
+++ b/.github/workflows/pull-request-token-metadata.yml
@@ -19,7 +19,7 @@ jobs:
   cargo-test-sbf:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set env vars
         run: |
@@ -34,20 +34,20 @@ jobs:
           override: true
           profile: minimal
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
           key: cargo-build-${{ hashFiles('**/Cargo.lock') }}-${{ env.RUST_STABLE}}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/rustfilt
           key: cargo-sbf-bins-${{ runner.os }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/solana
           key: solana-${{ env.SOLANA_VERSION }}

--- a/.github/workflows/pull-request-token-swap.yml
+++ b/.github/workflows/pull-request-token-swap.yml
@@ -19,7 +19,7 @@ jobs:
   cargo-test-sbf:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set env vars
         run: |
@@ -34,20 +34,20 @@ jobs:
           override: true
           profile: minimal
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
           key: cargo-build-${{ hashFiles('**/Cargo.lock') }}-${{ env.RUST_STABLE}}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/rustfilt
           key: cargo-sbf-bins-${{ runner.os }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/solana
           key: solana-${{ env.SOLANA_VERSION }}
@@ -75,7 +75,7 @@ jobs:
           mv target/deploy-production/spl_token_swap.so target/deploy/spl_token_swap_production.so
 
       - name: Upload programs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: token-swap-programs
           path: "target/deploy/*.so"
@@ -87,19 +87,19 @@ jobs:
       NODE_VERSION: 16.x
     needs: cargo-test-sbf
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.npm
           key: node-${{ hashFiles('token-swap/js/package-lock.json') }}
           restore-keys: |
             node-
       - name: Download programs
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: token-swap-programs
           path: target/deploy
@@ -108,7 +108,7 @@ jobs:
   fuzz:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set env vars
         run: |
@@ -123,21 +123,21 @@ jobs:
           override: true
           profile: minimal
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
           key: token-swap-fuzz-${{ hashFiles('**/Cargo.lock') }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/cargo-hfuzz
             ~/.cargo/bin/cargo-honggfuzz
           key: cargo-fuzz-bins-${{ runner.os }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cache

--- a/.github/workflows/pull-request-token-upgrade.yml
+++ b/.github/workflows/pull-request-token-upgrade.yml
@@ -19,7 +19,7 @@ jobs:
   cargo-test-sbf:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set env vars
         run: |
@@ -34,20 +34,20 @@ jobs:
           override: true
           profile: minimal
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
           key: cargo-build-${{ hashFiles('**/Cargo.lock') }}-${{ env.RUST_STABLE}}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/rustfilt
           key: cargo-sbf-bins-${{ runner.os }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/solana
           key: solana-${{ env.SOLANA_VERSION }}
@@ -64,7 +64,7 @@ jobs:
   cargo-build-test-cli:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set env vars
         run: |
@@ -79,14 +79,14 @@ jobs:
           override: true
           profile: minimal
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
           key: cargo-build-${{ hashFiles('**/Cargo.lock') }}-${{ env.RUST_STABLE }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/solana
           key: solana-${{ env.SOLANA_VERSION }}

--- a/.github/workflows/pull-request-token.yml
+++ b/.github/workflows/pull-request-token.yml
@@ -19,7 +19,7 @@ jobs:
   cargo-test-sbf:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Remove unneeded packages for more space
         run: bash ./ci/warning/purge-ubuntu-runner.sh
@@ -37,20 +37,20 @@ jobs:
           override: true
           profile: minimal
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
           key: cargo-build-${{ hashFiles('**/Cargo.lock') }}-${{ env.RUST_STABLE}}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/rustfilt
           key: cargo-sbf-bins-${{ runner.os }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/solana
           key: solana-${{ env.SOLANA_VERSION }}
@@ -65,7 +65,7 @@ jobs:
         run: ./ci/cargo-test-sbf.sh token
 
       - name: Upload programs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: token-programs
           path: "target/deploy/*.so"
@@ -74,7 +74,7 @@ jobs:
   cargo-test-token-2022-serde:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set env vars
         run: |
@@ -89,7 +89,7 @@ jobs:
           override: true
           profile: minimal
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -106,7 +106,7 @@ jobs:
   cargo-test-sbf-transfer-hook:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set env vars
         run: |
@@ -121,20 +121,20 @@ jobs:
           override: true
           profile: minimal
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
           key: cargo-build-${{ hashFiles('**/Cargo.lock') }}-${{ env.RUST_STABLE}}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/rustfilt
           key: cargo-sbf-bins-${{ runner.os }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/solana
           key: solana-${{ env.SOLANA_VERSION }}
@@ -149,7 +149,7 @@ jobs:
         run: ./ci/cargo-test-sbf.sh token/transfer-hook-example
 
       - name: Upload program
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: spl-transfer-hook-example
           path: "target/deploy/*.so"
@@ -158,7 +158,7 @@ jobs:
   cargo-test-sbf-associated-token-account:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set env vars
         run: |
@@ -173,20 +173,20 @@ jobs:
           override: true
           profile: minimal
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
           key: cargo-build-${{ hashFiles('**/Cargo.lock') }}-${{ env.RUST_STABLE}}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/rustfilt
           key: cargo-sbf-bins-${{ runner.os }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/solana
           key: solana-${{ env.SOLANA_VERSION }}
@@ -201,7 +201,7 @@ jobs:
         run: ./ci/cargo-test-sbf.sh associated-token-account
 
       - name: Upload program
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: associated-token-account-program
           path: "target/deploy/*.so"
@@ -210,7 +210,7 @@ jobs:
   cargo-test-sbf-twoxtx:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Remove unneeded packages for more space
         run: bash ./ci/warning/purge-ubuntu-runner.sh
@@ -229,7 +229,7 @@ jobs:
           override: true
           profile: minimal
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -255,29 +255,29 @@ jobs:
       NODE_VERSION: 16.x
     needs: [cargo-test-sbf, cargo-test-sbf-associated-token-account]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.npm
           key: node-${{ hashFiles('token/js/package-lock.json') }}
           restore-keys: |
             node-
       - name: Download programs
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: token-programs
           path: target/deploy
       - name: Download associated-token-account program
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: associated-token-account-program
           path: target/deploy
       - name: Download spl-transfer-hook-example program
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: spl-transfer-hook-example
           path: target/deploy
@@ -286,7 +286,7 @@ jobs:
   cargo-build-test-cli:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set env vars
         run: |
@@ -301,14 +301,14 @@ jobs:
           override: true
           profile: minimal
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
           key: cargo-build-${{ hashFiles('**/Cargo.lock') }}-${{ env.RUST_STABLE }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/solana
           key: solana-${{ env.SOLANA_VERSION }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -23,7 +23,7 @@ jobs:
   rustfmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set env vars
         run: |
@@ -46,7 +46,7 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set env vars
         run: |
@@ -60,7 +60,7 @@ jobs:
           profile: minimal
           components: clippy
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -82,7 +82,7 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set env vars
         run: |
@@ -107,7 +107,7 @@ jobs:
   cargo-build-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set env vars
         run: |
@@ -122,7 +122,7 @@ jobs:
           override: true
           profile: minimal
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -130,13 +130,13 @@ jobs:
             # target # Removed due to build dependency caching conflicts
           key: cargo-build-${{ hashFiles('**/Cargo.lock') }}-${{ env.RUST_STABLE}}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/rustfilt
           key: cargo-sbf-bins-${{ runner.os }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/solana
           key: solana-${{ env.SOLANA_VERSION }}

--- a/.github/workflows/spl_action.yml
+++ b/.github/workflows/spl_action.yml
@@ -10,9 +10,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         name: "importing all the document"
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: '16'
         name: "installing the node.js with version 16"

--- a/ci/solana-version.sh
+++ b/ci/solana-version.sh
@@ -23,7 +23,7 @@ export PATH="$HOME"/.local/share/solana/install/active_release/bin:"$PATH"
 if [[ -n $1 ]]; then
   case $1 in
   install)
-    sh -c "$(curl -sSfL https://release.solana.com/$solana_version/install)"
+    sh -c "$(curl -sSfL https://release.anza.xyz/$solana_version/install)"
     solana --version
     ;;
   *)

--- a/ci/solana-version.sh
+++ b/ci/solana-version.sh
@@ -14,7 +14,11 @@
 if [[ -n $SOLANA_VERSION ]]; then
   solana_version="$SOLANA_VERSION"
 else
-  solana_version=v1.16.13
+  # v1.16.13 (this branch's original pin) is EOL and no longer hosted by any release server
+  # (release.solana.com is decommissioned; release.anza.xyz only serves >=v1.17). Use the nearest
+  # anza-hosted release for the CI toolchain — crate deps stay pinned at 1.16.x via Cargo.lock, so
+  # only the build-sbf toolchain version moves.
+  solana_version=v1.17.34
 fi
 
 export solana_version="$solana_version"

--- a/libraries/tlv-account-resolution/src/account.rs
+++ b/libraries/tlv-account-resolution/src/account.rs
@@ -7,7 +7,9 @@ use {
     crate::{error::AccountResolutionError, pubkey_data::PubkeyData, seeds::Seed},
     bytemuck::{Pod, Zeroable},
     solana_program::{
-        account_info::AccountInfo, instruction::AccountMeta, program_error::ProgramError,
+        account_info::AccountInfo,
+        instruction::AccountMeta,
+        program_error::ProgramError,
         pubkey::{Pubkey, PUBKEY_BYTES},
     },
     spl_pod::primitives::PodBool,

--- a/libraries/tlv-account-resolution/src/account.rs
+++ b/libraries/tlv-account-resolution/src/account.rs
@@ -4,14 +4,57 @@
 //! collection of seeds
 
 use {
-    crate::{error::AccountResolutionError, seeds::Seed},
+    crate::{error::AccountResolutionError, pubkey_data::PubkeyData, seeds::Seed},
     bytemuck::{Pod, Zeroable},
     solana_program::{
         account_info::AccountInfo, instruction::AccountMeta, program_error::ProgramError,
-        pubkey::Pubkey,
+        pubkey::{Pubkey, PUBKEY_BYTES},
     },
     spl_pod::primitives::PodBool,
 };
+
+/// Resolve a `Pubkey` from a `PubkeyData` configuration — either from the
+/// instruction data or from the inner data of an account in the list.
+fn resolve_key_data<'a, F>(
+    key_data: &PubkeyData,
+    instruction_data: &[u8],
+    get_account_key_data_fn: F,
+) -> Result<Pubkey, ProgramError>
+where
+    F: Fn(usize) -> Option<(&'a Pubkey, Option<&'a [u8]>)>,
+{
+    match key_data {
+        PubkeyData::Uninitialized => Err(ProgramError::InvalidAccountData),
+        PubkeyData::InstructionData { index } => {
+            let key_start = *index as usize;
+            let key_end = key_start + PUBKEY_BYTES;
+            if key_end > instruction_data.len() {
+                return Err(AccountResolutionError::InstructionDataTooSmall.into());
+            }
+            Ok(Pubkey::new_from_array(
+                instruction_data[key_start..key_end].try_into().unwrap(),
+            ))
+        }
+        PubkeyData::AccountData {
+            account_index,
+            data_index,
+        } => {
+            let account_index = *account_index as usize;
+            let account_data = get_account_key_data_fn(account_index)
+                .ok_or::<ProgramError>(AccountResolutionError::AccountNotFound.into())?
+                .1
+                .ok_or::<ProgramError>(AccountResolutionError::AccountDataNotFound.into())?;
+            let arg_start = *data_index as usize;
+            let arg_end = arg_start + PUBKEY_BYTES;
+            if account_data.len() < arg_end {
+                return Err(AccountResolutionError::AccountDataTooSmall.into());
+            }
+            Ok(Pubkey::new_from_array(
+                account_data[arg_start..arg_end].try_into().unwrap(),
+            ))
+        }
+    }
+}
 
 /// Resolve a program-derived address (PDA) from the instruction data
 /// and the accounts that have already been resolved
@@ -140,6 +183,21 @@ impl ExtraAccountMeta {
         })
     }
 
+    /// Create an `ExtraAccountMeta` whose address is read from some data — the
+    /// instruction data or the inner data of another account in the list.
+    pub fn new_with_pubkey_data(
+        key_data: &PubkeyData,
+        is_signer: bool,
+        is_writable: bool,
+    ) -> Result<Self, ProgramError> {
+        Ok(Self {
+            discriminator: 2,
+            address_config: PubkeyData::pack_into_address_config(key_data)?,
+            is_signer: is_signer.into(),
+            is_writable: is_writable.into(),
+        })
+    }
+
     /// Resolve an `ExtraAccountMeta` into an `AccountMeta`, potentially
     /// resolving a program-derived address (PDA) if necessary
     pub fn resolve<'a, F>(
@@ -169,6 +227,14 @@ impl ExtraAccountMeta {
                         program_id,
                         get_account_key_data_fn,
                     )?,
+                    is_signer: self.is_signer.into(),
+                    is_writable: self.is_writable.into(),
+                })
+            }
+            2 => {
+                let key_data = PubkeyData::unpack(&self.address_config)?;
+                Ok(AccountMeta {
+                    pubkey: resolve_key_data(&key_data, instruction_data, get_account_key_data_fn)?,
                     is_signer: self.is_signer.into(),
                     is_writable: self.is_writable.into(),
                 })

--- a/libraries/tlv-account-resolution/src/error.rs
+++ b/libraries/tlv-account-resolution/src/error.rs
@@ -60,4 +60,13 @@ pub enum AccountResolutionError {
     /// Failed to fetch account
     #[error("Failed to fetch account")]
     AccountFetchFailed,
+    /// Not enough bytes available to pack pubkey data configuration.
+    #[error("Not enough bytes available to pack pubkey data configuration")]
+    NotEnoughBytesForPubkeyData,
+    /// The provided bytes are not valid for a pubkey data configuration
+    #[error("The provided bytes are not valid for a pubkey data configuration")]
+    InvalidBytesForPubkeyData,
+    /// Tried to pack an invalid pubkey data configuration
+    #[error("Tried to pack an invalid pubkey data configuration")]
+    InvalidPubkeyDataConfig,
 }

--- a/libraries/tlv-account-resolution/src/lib.rs
+++ b/libraries/tlv-account-resolution/src/lib.rs
@@ -9,6 +9,7 @@
 
 pub mod account;
 pub mod error;
+pub mod pubkey_data;
 pub mod seeds;
 pub mod state;
 

--- a/libraries/tlv-account-resolution/src/pubkey_data.rs
+++ b/libraries/tlv-account-resolution/src/pubkey_data.rs
@@ -1,0 +1,185 @@
+//! Types for managing extra account meta keys that may be extracted from some
+//! data.
+//!
+//! This can be either account data from some account in the list of accounts
+//! or from the instruction data itself.
+
+#[cfg(feature = "serde-traits")]
+use serde::{Deserialize, Serialize};
+use {crate::error::AccountResolutionError, solana_program::program_error::ProgramError};
+
+/// Enum to describe a required key stored in some data.
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
+pub enum PubkeyData {
+    /// Uninitialized configuration byte space.
+    Uninitialized,
+    /// A pubkey to be resolved from the instruction data.
+    ///
+    /// Packed as:
+    ///     * 1 - Discriminator
+    ///     * 1 - Start index of instruction data
+    ///
+    /// Note: Length is always 32 bytes.
+    InstructionData {
+        /// The index where the address bytes begin in the instruction data.
+        index: u8,
+    },
+    /// A pubkey to be resolved from the inner data of some account.
+    ///
+    /// Packed as:
+    ///     * 1 - Discriminator
+    ///     * 1 - Index of account in accounts list
+    ///     * 1 - Start index of account data
+    ///
+    /// Note: Length is always 32 bytes.
+    AccountData {
+        /// The index of the account in the entire accounts list.
+        account_index: u8,
+        /// The index where the address bytes begin in the account data.
+        data_index: u8,
+    },
+}
+impl PubkeyData {
+    /// Get the size of a pubkey data configuration.
+    pub fn tlv_size(&self) -> u8 {
+        match self {
+            Self::Uninitialized => 0,
+            // 1 byte for the discriminator, 1 byte for the index.
+            Self::InstructionData { .. } => 1 + 1,
+            // 1 byte for the discriminator, 1 byte for the account index,
+            // 1 byte for the data index.
+            Self::AccountData { .. } => 1 + 1 + 1,
+        }
+    }
+
+    /// Packs a pubkey data configuration into a slice.
+    pub fn pack(&self, dst: &mut [u8]) -> Result<(), ProgramError> {
+        // Because no `PubkeyData` variant is larger than 3 bytes, this check
+        // is sufficient for the data length.
+        if dst.len() != self.tlv_size() as usize {
+            return Err(AccountResolutionError::NotEnoughBytesForPubkeyData.into());
+        }
+        match &self {
+            Self::Uninitialized => {
+                return Err(AccountResolutionError::InvalidPubkeyDataConfig.into())
+            }
+            Self::InstructionData { index } => {
+                dst[0] = 1;
+                dst[1] = *index;
+            }
+            Self::AccountData {
+                account_index,
+                data_index,
+            } => {
+                dst[0] = 2;
+                dst[1] = *account_index;
+                dst[2] = *data_index;
+            }
+        }
+        Ok(())
+    }
+
+    /// Packs a pubkey data configuration into a 32-byte array, filling the
+    /// rest with 0s.
+    pub fn pack_into_address_config(key_data: &Self) -> Result<[u8; 32], ProgramError> {
+        let mut packed = [0u8; 32];
+        let tlv_size = key_data.tlv_size() as usize;
+        key_data.pack(&mut packed[..tlv_size])?;
+        Ok(packed)
+    }
+
+    /// Unpacks a pubkey data configuration from a slice.
+    pub fn unpack(bytes: &[u8]) -> Result<Self, ProgramError> {
+        let (discrim, rest) = bytes
+            .split_first()
+            .ok_or::<ProgramError>(ProgramError::InvalidAccountData)?;
+        match discrim {
+            0 => Ok(Self::Uninitialized),
+            1 => {
+                if rest.is_empty() {
+                    return Err(AccountResolutionError::InvalidBytesForPubkeyData.into());
+                }
+                Ok(Self::InstructionData { index: rest[0] })
+            }
+            2 => {
+                if rest.len() < 2 {
+                    return Err(AccountResolutionError::InvalidBytesForPubkeyData.into());
+                }
+                Ok(Self::AccountData {
+                    account_index: rest[0],
+                    data_index: rest[1],
+                })
+            }
+            _ => Err(ProgramError::InvalidAccountData),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pack() {
+        // Should fail if the length is too short.
+        let key = PubkeyData::InstructionData { index: 0 };
+        let mut packed = vec![0u8; key.tlv_size() as usize - 1];
+        assert_eq!(
+            key.pack(&mut packed).unwrap_err(),
+            AccountResolutionError::NotEnoughBytesForPubkeyData.into(),
+        );
+
+        // Should fail if the length is too long.
+        let key = PubkeyData::InstructionData { index: 0 };
+        let mut packed = vec![0u8; key.tlv_size() as usize + 1];
+        assert_eq!(
+            key.pack(&mut packed).unwrap_err(),
+            AccountResolutionError::NotEnoughBytesForPubkeyData.into(),
+        );
+
+        // Can't pack a `PubkeyData::Uninitialized`.
+        let key = PubkeyData::Uninitialized;
+        let mut packed = vec![0u8; key.tlv_size() as usize];
+        assert_eq!(
+            key.pack(&mut packed).unwrap_err(),
+            AccountResolutionError::InvalidPubkeyDataConfig.into(),
+        );
+    }
+
+    #[test]
+    fn test_unpack() {
+        // Can unpack zeroes.
+        let zeroes = [0u8; 32];
+        let key = PubkeyData::unpack(&zeroes).unwrap();
+        assert_eq!(key, PubkeyData::Uninitialized);
+
+        // Should fail for empty bytes.
+        let bytes = [];
+        assert_eq!(
+            PubkeyData::unpack(&bytes).unwrap_err(),
+            ProgramError::InvalidAccountData
+        );
+    }
+
+    fn test_pack_unpack_key(key: PubkeyData) {
+        let tlv_size = key.tlv_size() as usize;
+        let mut packed = vec![0u8; tlv_size];
+        key.pack(&mut packed).unwrap();
+        let unpacked = PubkeyData::unpack(&packed).unwrap();
+        assert_eq!(key, unpacked);
+    }
+
+    #[test]
+    fn test_pack_unpack() {
+        // Instruction data.
+        test_pack_unpack_key(PubkeyData::InstructionData { index: 0 });
+
+        // Account data.
+        test_pack_unpack_key(PubkeyData::AccountData {
+            account_index: 0,
+            data_index: 0,
+        });
+    }
+}

--- a/token/program-2022/src/entrypoint.rs
+++ b/token/program-2022/src/entrypoint.rs
@@ -1,5 +1,8 @@
 //! Program entrypoint
 
+// `entrypoint` (the macro) is only used by the `entrypoint!` invocation below, which is compiled
+// out under `no-entrypoint`; `entrypoint::ProgramResult` is always used.
+#[allow(unused_imports)]
 use {
     crate::{error::TokenError, processor::Processor},
     solana_program::{

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -45,6 +45,7 @@ use {
 
 #[cfg(feature = "serde-traits")]
 use serde::{Deserialize, Serialize};
+#[allow(unused_imports)] // used only under some feature combinations (backported extensions)
 use spl_pod::{optional_keys::OptionalNonZeroPubkey, primitives::PodBool};
 
 /// Confidential Transfer extension

--- a/token/program-2022/src/extension/scaled_ui_amount/processor.rs
+++ b/token/program-2022/src/extension/scaled_ui_amount/processor.rs
@@ -1,3 +1,8 @@
+// "Basic support" backport: the ScaledUiAmount instruction processing is intentionally not wired
+// into the program's instruction dispatch (klend only needs the extension to be *recognized*), so
+// these processor fns are currently unreferenced.
+#![allow(dead_code)]
+
 use {
     crate::{
         check_program_account,

--- a/token/transfer-hook-interface/src/onchain.rs
+++ b/token/transfer-hook-interface/src/onchain.rs
@@ -73,14 +73,54 @@ pub fn add_cpi_accounts_for_execute<'a>(
         .find(|&x| x.key == program_id)
         .ok_or(TransferHookError::IncorrectAccount)?;
 
+    // The extra-account metas must be resolved as if for an `Execute` *into the hook program* —
+    // seed-derived (PDA) metas are derived against `cpi_instruction.program_id`, so resolving
+    // against the (token-program) transfer-checked instruction would derive PDAs against the wrong
+    // program. We therefore build a standalone `Execute` instruction (program id = the hook), let
+    // `add_to_cpi_instruction` resolve the metas against it, then graft the resolved *extra*
+    // accounts (everything past the 5 standard ones) onto the real transfer-checked CPI.
+    //
+    // The first four accounts of the transfer-checked CPI are, in order, source/mint/destination/
+    // authority — the leading accounts of an `Execute`. The transfer amount (needed for any
+    // `Seed::InstructionData` metas) is parsed from the transfer-checked instruction data
+    // (`[tag, amount: u64, decimals]`).
+    let amount = cpi_instruction
+        .data
+        .get(1..9)
+        .and_then(|bytes| bytes.try_into().ok())
+        .map(u64::from_le_bytes)
+        .unwrap_or(0);
+    let mut execute_instruction = instruction::execute(
+        program_id,
+        cpi_account_infos[0].key,
+        cpi_account_infos[1].key,
+        cpi_account_infos[2].key,
+        cpi_account_infos[3].key,
+        &validation_pubkey,
+        amount,
+    );
+    let mut execute_account_infos = vec![
+        cpi_account_infos[0].clone(),
+        cpi_account_infos[1].clone(),
+        cpi_account_infos[2].clone(),
+        cpi_account_infos[3].clone(),
+        validation_info.clone(),
+    ];
+
     ExtraAccountMetaList::add_to_cpi_instruction::<instruction::ExecuteInstruction>(
-        cpi_instruction,
-        cpi_account_infos,
+        &mut execute_instruction,
+        &mut execute_account_infos,
         &validation_info.try_borrow_data()?,
         additional_accounts,
     )?;
-    // The onchain helpers pull out the required accounts from an opaque
-    // slice by pubkey, so the order doesn't matter here!
+
+    // Graft the resolved extra accounts (past source/mint/destination/authority/validation) onto
+    // the transfer-checked CPI, then the validation state and the hook program itself.
+    cpi_instruction
+        .accounts
+        .extend_from_slice(&execute_instruction.accounts[5..]);
+    cpi_account_infos.extend_from_slice(&execute_account_infos[5..]);
+
     cpi_account_infos.push(validation_info.clone());
     cpi_account_infos.push(program_info.clone());
     cpi_instruction


### PR DESCRIPTION
## What

Backports two transfer-hook extra-account **resolution** capabilities onto the `spl-token-2022-v0.9.0-patched` line, so downstreams (klend) can support Token-2022 transfer hooks whose `ExtraAccountMetaList` uses **seed-derived** and **pubkey-data** extra accounts — e.g. [securitize's `policy_engine`](https://github.com/securitize-io/rwa-token/blob/main/programs/policy_engine/src/instructions/execute.rs), which declares `new_with_seeds` (policy-engine + tracker accounts) and `new_with_pubkey_data` (identity accounts) metas.

A full version bump isn't viable (current `master` tlv/interface require Solana 2.x), so these are minimal source backports onto the existing v0.9.0 crates.

## Changes

### `transfer-hook-interface` — `add_cpi_accounts_for_execute`
Resolve the `ExtraAccountMetaList` metas against a standalone `Execute` instruction whose program id is the **hook program**, then graft the resolved extra accounts onto the transfer-checked CPI. Previously the metas were resolved against the transfer-checked instruction directly, so seed-derived (`new_with_seeds`) PDAs were derived against the **token** program → wrong addresses → `AccountResolutionError::IncorrectAccount`.

Mirrors the approach `master` adopted in `add_extra_accounts_for_execute_cpi`:
- `token/transfer-hook/interface/src/onchain.rs` (interface `v0.8.2`), `master` @ `82ad10add`

### `tlv-account-resolution` — `PubkeyData` support
Backports `PubkeyData` / `new_with_pubkey_data` (discriminator `2`): a new `pubkey_data.rs` module, the disc-2 resolve arm + `resolve_key_data` helper in `account.rs`, and the corresponding error variants. Lets an extra-account address be read from instruction data or from another account's data.

Ported from `master` (tlv `v0.8.1`):
- `libraries/tlv-account-resolution/src/pubkey_data.rs`
- disc-2 handling in `libraries/tlv-account-resolution/src/account.rs`
- Upstream origin: solana-labs/solana-program-library#6847 — *"TLV Account Resolution: Add support for keys in data"*

## Validation
- `spl-token-2022` (v0.9.0) builds; `spl-tlv-account-resolution` unit tests pass.
- Exercised end-to-end from klend (this branch built as a BPF `.so` and loaded into `ProgramTest`): a hooked transfer whose `ExtraAccountMetaList` uses **both** a `new_with_seeds` and a `new_with_pubkey_data` meta resolves correctly and the hook executes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
